### PR TITLE
Added docs folder with public README and oomph setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# IMPORTANT
+
+The content of this folder and it's subfolders is **public** under https://devonfw.github.io/training-devon-server

--- a/docs/oomph/projects/TrainingDevonServer.setup
+++ b/docs/oomph/projects/TrainingDevonServer.setup
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Project
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:git="http://www.eclipse.org/oomph/setup/git/1.0"
+    xmlns:maven="http://www.eclipse.org/oomph/setup/maven/1.0"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 http://de-mucevolve02/oomph/tasks/models/Git.ecore http://www.eclipse.org/oomph/setup/maven/1.0 http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/models/Maven.ecore"
+    name="training.devon.server"
+    label="training-devon-server">
+  <setupTask
+      xsi:type="git:GitCloneTask"
+      id="git.clone.training.devon.server"
+      location="${workspace.location/${scope.project.label}}"
+      remoteURI="${github.remote.uri}"
+      pushURI="${github.remote.uri}">
+    <description></description>
+  </setupTask>
+  <setupTask
+      xsi:type="setup:VariableTask"
+      name="github.remote.uri"
+      storageURI="scope://Workspace">
+    <choice
+        value="https://github.com/${github.repo.owner}/${github.repo.name}.git"
+        label="HTTPS"/>
+    <choice
+        value="ssh://git@github:${github.repo.owner}/${github.repo.name}.git"
+        label="SSH"/>
+  </setupTask>
+  <setupTask
+      xsi:type="setup:VariableTask"
+      name="github.repo.owner"
+      defaultValue="devonfw"
+      storageURI="scope://Workspace"
+      label="Repository Owner"/>
+  <setupTask
+      xsi:type="setup:VariableTask"
+      name="github.repo.name"
+      value="training-devon-server"
+      storageURI="scope://Workspace"
+      label="Repository Owner"/>
+  <setupTask
+      xsi:type="maven:MavenImportTask">
+    <sourceLocator
+        rootFolder="${git.clone.training.devon.server.location}"/>
+  </setupTask>
+  <stream name="develop"
+      label="Develop"/>
+  <stream name="master"
+      label="Master"/>
+  <stream name="reference-solution"
+      label="Reference Solution"/>
+  <logicalProjectContainer
+      xsi:type="setup:ProjectCatalog"
+      href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']"/>
+  <description>The Open Application Standard Platform for Java</description>
+</setup:Project>


### PR DESCRIPTION
Currently I'm working on an Oomph Project Catalog for devon. This provides a fast and easy setup for the ide and projects. 

To do so we decided to keep the corresponding project setups at the projects gh-pages. 

This PR adds the `docs` folder containing the oomph setups. To make it accessible you'll need to active this repos gh-pages based on the docs folder of the masterbranch. The setups itself reveal nothing of the repository except it's existence.